### PR TITLE
Update content

### DIFF
--- a/getting-started.md
+++ b/getting-started.md
@@ -3,20 +3,8 @@
 Now you can:
 
 - Visit your Rotki **dashboard**: **[rotki.dappnode](http://rotki.dappnode/)**.
-- Rotki must have access to a syncronized Eth1.x mainnet node. 
+- Rotki must have access to a synchronized Ethereum node. You will need to have installed an Execution client and Consensus client(Prysm, Teku, Lighthouse or Nimbus) You can do that from System > Repository or directly from the stakers-ui.
 
-    If you have not already, make sure to install and sync an Eth1.x node of your choice. 
-
-    Then, go to [settings](http://rotki.dappnode/settings/general) > `LOCAL NODES` input the URL of the node that you wish to use or a remote one:
-        
-    * Geth `http://geth.dappnode:8545` - [Install link](http://my.dappnode/#/installer/geth.dnp.dappnode.eth)
-
-    * Turbo Geth `http://turbo-geth.dappnode:8545` - [Install link](http://my.dappnode/#/installer/turbo-geth.dnp.dappnode)
-
-    * OpenEthereum `http://openethereum.dappnode:8545` - [Install link](http://my.dappnode/#/installer/openethereum.dnp.dappnode.eth)
-
-    * Nethermind `http://nethermind.public.dappnode:8545` - [Install link](http://my.dappnode/#/installer/nethermind.public.dappnode.eth)
-
-    * Remote node (example URL) `https://remote-node-provider.io`
+You can find in the Rotki documentation the information on the different nodes you can use [Rotki](https://rotki.readthedocs.io/en/latest/usage_guide.html#rpc-nodes)
 
 - Explore the [Rotki documentation](https://rotki.readthedocs.io/en/latest/usage_guide.html) for more information about what can you do with Rotki.


### PR DESCRIPTION
There is outdated content in the getting started information. We have added a link to the docs of rotki and we say to the user he needs to install an execution an a consensus client of ethereum network.