### PR TITLE
Introduce env variable required by next rotki release

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -9,6 +9,8 @@ services:
     volumes:
       - "rotki_data:/data"
       - "rotki_logs:/logs"
+    environment:
+      ROTKI_ACCEPT_DOCKER_RISK: 1
     restart: always
 volumes:
   rotki_data: {}


### PR DESCRIPTION
In the upcoming 1.27.0 release, we are introducing a [security warning](https://rotki.readthedocs.io/en/latest/usage_guide.html#docker) for users using the docker image directly.

This warning will appear to the users every time they go to the login screen until they set the environment variable `ROTKI_ACCEPT_DOCKER_RISK=1`. The purpose of this addition is to make people aware that is it not safe to use the docker image directly exposed to a public network.

Since DAppNode is not exposing the apps directly but they are accessed only through the VPN it makes sense to set the var in the package.

