### PR TITLE
Upgrade rotki to 1.28.0

### DIFF
--- a/dappnode_package.json
+++ b/dappnode_package.json
@@ -1,7 +1,7 @@
 {
   "name": "rotki.dnp.dappnode.eth",
   "version": "0.1.0",
-  "upstreamVersion": "v1.27.1",
+  "upstreamVersion": "v1.28.0",
   "architectures": ["linux/amd64", "linux/arm64"],
   "upstreamRepo": "rotki/rotki",
   "upstreamArg": "UPSTREAM_VERSION",

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -5,7 +5,7 @@ services:
     build:
       context: .
       args:
-        UPSTREAM_VERSION: v1.27.1
+        UPSTREAM_VERSION: v1.28.0
     volumes:
       - "rotki_data:/data"
       - "rotki_logs:/logs"


### PR DESCRIPTION
Release 1.28.0 was publised on May 17 and contains important changes and several bugfixes. Changelog can be seen here https://github.com/rotki/rotki/releases/tag/v1.28.0