### PR TITLE
Set seccomp to unconfined

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,7 +1,7 @@
 version: "3.5"
 services:
   rotki.dnp.dappnode.eth:
-    image: rotki.dnp.dappnode.eth:0.1.0
+    image: rotki.dnp.dappnode.eth:0.1.29
     build:
       context: .
       args:
@@ -13,6 +13,8 @@ services:
       ROTKI_ACCEPT_DOCKER_RISK: 1
       LOGLEVEL: info
     restart: unless-stopped
+    security_opt:
+      - seccomp:unconfined
 volumes:
   rotki_data: {}
   rotki_logs: {}


### PR DESCRIPTION
The current dappnode package fails to start with the following error:

```
RuntimeError: can't start new thread
```

This suggests that the used Python has issues with the seccomp profile being used. This PR provides a quick workaround which made the package work for me again. A proper fix might involve checking out the installation of Python within the Docker image.